### PR TITLE
Add `n` command to set NetVM for one or more VMs. Supports aliases for both the VMs and the NetVM.

### DIFF
--- a/qubes-terminal-hotkeys
+++ b/qubes-terminal-hotkeys
@@ -393,6 +393,33 @@ fi
 return $ret
 }
 
+#maction_netvm [vm 1] ... [vm n] [netvm]
+#Assigns <netvm> as netVM for the given VMs
+function maction_netvm {
+
+# At least one VM to set netVM for, and a netVM name
+if [[ "$#" -lt 2 ]]; then
+    errorOut "You must provide a netVM name as argument"
+fi
+
+local netVM="${*: -1}"
+declare -a vms=("${@:1:$#-1}")
+
+# netVM must actually provide network
+if [[ "$netVM" != 'None' ]] && [[ "$(qvm-prefs "$netVM" provides_network)" == "False" ]]; then
+    errorOut "VM $netVM does provide network"
+fi
+
+# Change netvm for each VM
+for vm in "${vms[@]}" ; do
+    [ $VERBOSE -eq 0 ] && echo "Assigning $netVM as netVM for: $*"
+    qvm-prefs "$vm" netvm "$netVM"
+    ret=$?
+done
+
+return $ret
+}
+
 #maction_kill [vm 1] ... [vm n]
 #Kill the given VMs.
 function maction_kill {

--- a/qubes-terminal-hotkeys.conf
+++ b/qubes-terminal-hotkeys.conf
@@ -18,6 +18,7 @@ declare -A HOTKEYS=(
 	[s]="maction_shutdown"
 	[m]="action_mute"
 	[u]="action_unmute"
+    [n]="action_netvm"
 	#[k]="maction_kill"
 	#[p]="maction_pause"
 	)


### PR DESCRIPTION

Hello, great little piece of code, really helps a lot !

Given some users might have to change the NetVM for some of their VMs some times,
maybe they would like to do it with one of those shortcuts.

Therefore I have added a small function that helps doing this.
It works the following:

```
n myVM-1 myVM-2 MyNetVM
```

where `myVM-1` and `myVM-2` will be assigned `MyNetVM` as their new netVM.
Also, the value `None` works, and obviously cuts the network access of these VMs.

I hope this will be useful.
